### PR TITLE
use 'raw.githubusercontent.com' in one-liner

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 To install zplug to your system, run this command:
 
 ```zsh
-$ curl -sL zplug.sh/installer | zsh
+$ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh| zsh
 ```
 
 **Things to do**


### PR DESCRIPTION
The old one-liner is not working now because The domain 'zplug.sh' has expired.
This pull request fix one-liner URL.
