### PR TITLE
Fix installer doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 To install zplug to your system, run this command:
 
 ```zsh
-$ curl -sL zplug.sh/installer | zsh
+$ curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
 ```
 
 **Things to do**


### PR DESCRIPTION
The installer command in the previous version of README gives the following error.

```
$ curl -sL zplug.sh/installer
<?xml version="1.0" encoding="UTF-8"?>
<Error><Code>AccessDenied</Code><Message>Access Denied</Message><RequestId>DC88925B68D518F3</RequestId><HostId>8j1EXmZIwDAkCvbkBceVcCamxYyIpdRaDsSSq6k8vvBnn9bkyuJ4uH5VRF/gHdS0Q~ »
```