### PR TITLE
reset the cursor position when exit installer

### DIFF
--- a/installer.zsh
+++ b/installer.zsh
@@ -1,5 +1,7 @@
 #!/bin/zsh
 
+trap 'tput cnorm' EXIT 2
+
 # Release some autoloads
 autoload -Uz colors; colors
 autoload -Uz is-at-least; is-at-least


### PR DESCRIPTION
Corrected that the cursor hides when forcibly terminating the installation script.